### PR TITLE
flake-registry: add more tulip links and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Tulip Nix registry
+
+This repo hosts a pointer to all the flakes that we use at tulip
+This is a json file that lets is run `nix run ponte -- -help` or `nix shell idd`  or (eventually) `nix run oplogtoredis`
+
+### Usage 
+
+To use, modify ~/.config/nix/nix.conf to add the following line:
+
+```
+flake-registry = https://github.com/tulip/flake-registry/releases/download/v1.2.0/flake-registry.json
+```
+
+Where `v1.2.0` should be replaced with the most recent version.

--- a/flake-registry.json
+++ b/flake-registry.json
@@ -188,6 +188,40 @@
         "repo": "flocoPackages",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "ponte",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "tulip",
+        "repo": "rafflesia",
+        "type": "github",
+        "dir": "ponte"
+      }
+    },
+    {
+      "from": {
+        "id": "oplogtoredis",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "tulip",
+        "repo": "oplogtoredis",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
+        "id": "arboretum",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "tulip",
+        "repo": "arboretum",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
Add a link to arboretum, oplog2redis, ponte.

Also add a README saying how to use the tulip flake registry in your nix user conf.